### PR TITLE
Questions anywhere: display grades decimal based on config setting #363724

### DIFF
--- a/classes/attempt_summary_table.php
+++ b/classes/attempt_summary_table.php
@@ -152,7 +152,7 @@ class attempt_summary_table extends table_sql {
         if ($attempt->questionstate === 'todo') {
             return null;
         }
-        return $attempt->fraction . '/' . $attempt->maxmark;
+        return utils::get_grade($this->courseid, $attempt->fraction, $attempt->maxmark);
     }
 
     protected function col_questionattemptsteptime($row) {

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -186,4 +186,19 @@ class utils
         }
         return $url;
     }
+
+    /**
+     * Return formatted grade base on greade_decimalpoints setting.
+     * @param int $courseid
+     * @param float $fraction
+     * @param float $amaxmark
+     * @return string
+     */
+    public static function get_grade($courseid, $fraction, $amaxmark) {
+        global $CFG;
+        $decimalpoints = grade_get_setting($courseid, 'decimalpoints', $CFG->grade_decimalpoints);
+        $grade = format_float($fraction, $decimalpoints);
+        $maxgrade = format_float($amaxmark, $decimalpoints);
+        return $grade . '/' . $maxgrade;
+    }
 }

--- a/tests/utils_test.php
+++ b/tests/utils_test.php
@@ -59,7 +59,7 @@ class report_embedquestion_utils_testcase extends advanced_testcase {
         $attempt->pageurl = '/mod/page/view.php?id=' . $page1->id;
         $attempt->embedid = $catid . '/' . $question->idnumber;
         $embedid = $attempt->embedid;
-        $expected = "<a href=\"https://www.example.com/moodle/mod/page/view.php?id=$cmid#$embedid\">Page 1</a>";
+        $expected = "<a href=\"https://www.example.com/moodle/mod/page/view.php?id=$cmid#$embedid\">$attempt->pagename</a>";
         $actual = \report_embedquestion\utils::get_activity_link($attempt);
         $this->assertEquals($expected, $actual);
     }
@@ -73,5 +73,17 @@ class report_embedquestion_utils_testcase extends advanced_testcase {
         $expected = "<a href=\"https://www.example.com/moodle/user/view.php?id=$userid&amp;course=$courseid\">$username</a>";
         $actual = \report_embedquestion\utils::get_user_link($this->course->id, $user->id, $user->username);
         $this->assertEquals($expected, $actual);
+    }
+
+    public function test_get_grade() {
+        global $CFG;
+        $courseid = $this->course->id;
+        $fraction = 0.6666667;
+        $amaxmark = 1.0000000;
+        $decimalpoints = grade_get_setting($courseid, 'decimalpoints', $CFG->grade_decimalpoints);
+        if ($decimalpoints == 2) { // Default decimal point
+            $actual = utils::get_grade($courseid, $fraction, $amaxmark);
+            $this->assertEquals('0.67/1.00', $actual);
+        }
     }
 }


### PR DESCRIPTION
There is a minor unrelated change in report/embedquestion/tests/utils_test.php 