### PR TITLE
Bump version requirement to 5.2

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2026050400;
-$plugin->requires  = 2024042200;
+$plugin->requires  = 2026042000;
 $plugin->component = 'report_embedquestion';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = '2.0 for Moodle 5.2+';


### PR DESCRIPTION
the new version is explicitely labelled as 5.2+ but core version requirement wasn't declared as 5.2 / 2026042000

https://moodledev.io/general/releases#moodle-52